### PR TITLE
Catch panic from deserealize_enum()

### DIFF
--- a/src/de/deserializer/mod.rs
+++ b/src/de/deserializer/mod.rs
@@ -319,7 +319,13 @@ where
             .map_err(|error| {
                 DeserializationError::io_error(format!("enum {}", name), error)
             })?;
-        let variant_name = variants[variant as usize];
+
+        let variant_name = match variants.get(variant as usize) {
+                Some(val) => val,
+                None => Err(DeserializationError::Custom {
+                    message: format!("Cant match received variant {} with possible variants {:?}", variant, variants)
+                })?,
+        };
 
         let enum_deserializer =
             EnumDeserializer::new(name, variant, variant_name, self);


### PR DESCRIPTION
Sometimes we receive unexpected variant which we
cant compare with our Enum directly. We dont want
to receive panic by invalid external message.

By this reason we replace arr[idx] by arr.get(idx)